### PR TITLE
Fix typo in requirements.txt: colorma → colorama

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-colorma
+colorama
 prettytable


### PR DESCRIPTION
This corrects a typo in requirements.txt